### PR TITLE
Simplified use in your own packages

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 ChangeLog for Log-Contextual
 
+0.00305 2011-07-20
+  - Add 'warn' and 'env_prefix_for' parameters as shortcuts.
+
 0.00304 2010-07-31
   - Add $package_UPTO environment variable for WarnLogger
 

--- a/lib/Log/Contextual/WarnLogger.pm
+++ b/lib/Log/Contextual/WarnLogger.pm
@@ -34,8 +34,14 @@ sub new {
   my ($class, $args) = @_;
   my $self = bless {}, $class;
 
-  $self->{env_prefix} = $args->{env_prefix} or
-     die 'no env_prefix passed to Log::Contextual::WarnLogger->new';
+  my $env_prefix = $args->{env_prefix};
+  if ($args->{env_prefix_for}) {
+    $env_prefix = uc($args->{env_prefix_for});
+    $env_prefix =~ s/::/_/g;
+  }
+
+  $self->{env_prefix} = $env_prefix or
+     die 'no env_prefix or env_prefix_for passed to Log::Contextual::WarnLogger->new';
   return $self;
 }
 
@@ -84,16 +90,17 @@ works.
 
 =head2 new
 
-Arguments: C<< Dict[ env_prefix => Str ] $conf >>
+Arguments: C<< Dict[ env_prefix => Str | env_prefix_for => Str ] $conf >>
 
  my $l = Log::Contextual::WarnLogger->new({
-   env_prefix
+   env_prefix     => 'FREWS_PACKAGE'  # either literal prefix
+   env_prefix_for => 'Frews::Package' # or module name that is transformed
  });
 
 Creates a new logger object where C<env_prefix> defines what the prefix is for
 the environment variables that will be checked for the six log levels.  For
-example, if C<env_prefix> is set to C<FREWS_PACKAGE> the following environment
-variables will be used:
+example, if C<env_prefix> is set to C<FREWS_PACKAGE> or C<env_prefix_for> is
+set to C<Frews::Package>, the following environment variables will be used:
 
  FREWS_PACKAGE_UPTO
 
@@ -107,6 +114,7 @@ variables will be used:
 Note that C<UPTO> is a convenience variable.  If you set
 C<< FOO_UPTO=TRACE >> it will enable all log levels.  Similarly, if you
 set it to C<FATAL> only fatal will be enabled.
+
 
 =head2 $level
 

--- a/t/warnlogger.t
+++ b/t/warnlogger.t
@@ -83,5 +83,14 @@ my $l = Log::Contextual::WarnLogger->new({ env_prefix => 'BAR' });
    is($cap, "[error] error\n", 'error renders correctly');
    log_fatal { 'fatal' };
    is($cap, "[fatal] fatal\n", 'fatal renders correctly');
-
 }
+
+$l = Log::Contextual::WarnLogger->new({ env_prefix_for => 'Baz::Doz' });
+
+{
+   local $ENV{BAZ_DOZ_TRACE} = 0;
+   local $ENV{BAZ_DOZ_DEBUG} = 1;
+   ok(!$l->is_trace, 'trace set, env_prefix_for');
+   ok($l->is_debug, 'debug set, env_prefix_for');
+}
+

--- a/t/warnmodule.t
+++ b/t/warnmodule.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use Log::Contextual qw{:log set_logger};
+use Log::Contextual::SimpleLogger;
+use Test::More qw(no_plan);
+
+my $var;
+my $var_logger = Log::Contextual::SimpleLogger->new({
+   levels  => [qw(trace debug info warn error fatal)],
+   coderef => sub { $var = shift },
+});
+
+{
+   package Doz;
+   use Log::Contextual qw{:log}, -default_logger => 'warn';
+
+   sub new {
+      log_debug { 'doz' };
+   }
+}
+
+Doz->new;
+is( $var, undef, 'logging disabled by default' );
+
+{
+   my $w;
+   local $SIG{__WARN__} = sub { $w = shift };
+
+   $ENV{DOZ_DEBUG} = 1;
+   Doz->new;
+   is( $w, "[debug] doz\n", "logging enabled, warning emitted" );
+}
+
+set_logger($var_logger);
+Doz->new;
+is( $var, "[debug] doz\n", "logger set, logging catched" );
+


### PR DESCRIPTION
I experimented with several ways and ended up extending Log::Contextual. Backwards compatibility is ensured and it is covered by unit tests. You can now use:

```
package My::Module;
use Log::Contextual qw(:log), -default_logger => 'warn';
```

instead of

```
package My::Module;
use Log::Contextual::WarnLogger;
use Log::Contextual qw(:log), -default_logger
    => Log::Contextual::WarnLogger->new({ env_prefix => 'MY_MODULE' });
```

It is only two lines less, but in every single module plus it removes the redundancy of writing "My::Module" and "MY_MODULE" (which people may damage if they just copy & paste). I'd be happy if you include this patch and release a new version at CPAN, so I can use Log::Contextual in my CPAN modules.
