### PR TITLE
don't skip exports that exist in parent class

### DIFF
--- a/lib/Log/Contextual.pm
+++ b/lib/Log/Contextual.pm
@@ -33,7 +33,9 @@ my @log = ((map "log_$_", @levels), (map "logS_$_", @levels));
 sub _maybe_export {
    my ($spec, $target, $name, $new_code) = @_;
 
-   if (my $code = $target->can($name)) {
+   no strict 'refs';
+   if (defined &{"${target}::${name}"}) {
+      my $code = \&{"${target}::${name}"};
 
       # this will warn
       $spec->add_export("&$name", $new_code)

--- a/t/inherit.t
+++ b/t/inherit.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+
+use Log::Contextual qw(set_logger);
+use Log::Contextual::SimpleLogger;
+
+BEGIN {
+    package MySuperClass;
+    use Log::Contextual qw(:log);
+}
+
+BEGIN {
+    package MyChildClass;
+    BEGIN { our @ISA = qw(MySuperClass) };
+    use Log::Contextual qw(:log);
+
+    sub do_thing {
+        log_error { "child class log" };
+    }
+}
+
+my $last_log;
+set_logger(Log::Contextual::SimpleLogger->new({
+    levels  => [qw(error)],
+    coderef => sub { $last_log = shift },
+}));
+
+is exception { MyChildClass->do_thing; }, undef,
+  'log imports work in child class with exports in parent';
+
+done_testing;


### PR DESCRIPTION
Check the fully qualified sub we are trying to export rather than using
can, otherwise we skip exporting subs that exist in the parent class.