### PR TITLE
drop Exporter::Declare dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,4 @@
 requires 'Data::Dumper::Concise' => 0;
-requires 'Exporter::Declare' => 0.111;
 requires 'Carp' => 0;
 requires 'Scalar::Util' => 0;
 requires 'Moo' => 1.003000;

--- a/lib/Log/Contextual/Easy/Default.pm
+++ b/lib/Log/Contextual/Easy/Default.pm
@@ -12,7 +12,7 @@ sub arg_default_logger {
       return $_[1];
    } else {
       require Log::Contextual::WarnLogger;
-      my $package = uc(caller(2));
+      my $package = uc $_[2];
       $package =~ s/::/_/g;
       return Log::Contextual::WarnLogger->new({env_prefix => $package});
    }

--- a/lib/Log/Contextual/Easy/Default.pm
+++ b/lib/Log/Contextual/Easy/Default.pm
@@ -12,7 +12,7 @@ sub arg_default_logger {
       return $_[1];
    } else {
       require Log::Contextual::WarnLogger;
-      my $package = uc(caller(3));
+      my $package = uc(caller(2));
       $package =~ s/::/_/g;
       return Log::Contextual::WarnLogger->new({env_prefix => $package});
    }

--- a/lib/Log/Contextual/Easy/Package.pm
+++ b/lib/Log/Contextual/Easy/Package.pm
@@ -12,7 +12,7 @@ sub arg_package_logger {
       return $_[1];
    } else {
       require Log::Contextual::WarnLogger;
-      my $package = uc(caller(3));
+      my $package = uc(caller(2));
       $package =~ s/::/_/g;
       return Log::Contextual::WarnLogger->new({env_prefix => $package});
    }

--- a/lib/Log/Contextual/Easy/Package.pm
+++ b/lib/Log/Contextual/Easy/Package.pm
@@ -12,7 +12,7 @@ sub arg_package_logger {
       return $_[1];
    } else {
       require Log::Contextual::WarnLogger;
-      my $package = uc(caller(2));
+      my $package = uc $_[2];
       $package =~ s/::/_/g;
       return Log::Contextual::WarnLogger->new({env_prefix => $package});
    }

--- a/lib/Log/Contextual/Router.pm
+++ b/lib/Log/Contextual/Router.pm
@@ -42,15 +42,15 @@ sub after_import {
    my $target   = $import_info{target};
    my $config   = $import_info{arguments};
 
-   if (my $l = $exporter->arg_logger($config->{logger})) {
+   if (my $l = $exporter->arg_logger($config->{logger}, $target)) {
       $self->set_logger($l);
    }
 
-   if (my $l = $exporter->arg_package_logger($config->{package_logger})) {
+   if (my $l = $exporter->arg_package_logger($config->{package_logger}, $target)) {
       $self->_set_package_logger_for($target, $l);
    }
 
-   if (my $l = $exporter->arg_default_logger($config->{default_logger})) {
+   if (my $l = $exporter->arg_default_logger($config->{default_logger}, $target)) {
       $self->_set_default_logger_for($target, $l);
    }
 }


### PR DESCRIPTION
Exporter::Declare is rather weird and we have to do a lot of work
wrapping it anyway. It brings in a number of dependencies that are not
widely used. Replace it with an ad hoc solution.

This also allows being more consistent. Log::Contextual did not account
for all of the options Exporter::Declare provides, like renames.